### PR TITLE
Add conditional compile for OS X to adhere to HIG.

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -46,7 +46,11 @@ MainWindow::MainWindow(QWidget *parent) :
     connect(open,SIGNAL(triggered()),this,SLOT(show()));
     trayMenu->addAction(open);
 
+#ifdef Q_WS_MAC
+    QAction* setting = new QAction(QString::fromUtf8("Preferences…"),this);
+#else
     QAction* setting = new QAction("Settings",this);
+#endif
     connect(setting,SIGNAL(triggered()),settingsDialog,SLOT(show()));
     trayMenu->addAction(setting);
 


### PR DESCRIPTION
As per Apple's OS X human interface guidelines, the Settings menu item
on OS X builds has been renamed "Preferences…". Menu items that result
in the opening of a dialog or new window should have a trailing ellipsis
character.

QString::fromUtf8() is required as the ellipsis character is not within
the ASCII character set.
